### PR TITLE
Add metadata fields for user series

### DIFF
--- a/src/components/AddSerieModal/index.tsx
+++ b/src/components/AddSerieModal/index.tsx
@@ -168,7 +168,12 @@ const AddSerieModal: FC<AddSerieModalProps> = ({
                 variant="primary"
                 title={t('modal.confirm')}
                 onPress={handleConfirm}
-                disabled={!selectedStatus || isLoading || isRemoving}
+                disabled={
+                  !selectedStatus ||
+                  isLoading ||
+                  isRemoving ||
+                  initialStatus === selectedStatus
+                }
                 isLoading={isLoading}
               />
             </View>

--- a/src/components/SeriesCard/index.tsx
+++ b/src/components/SeriesCard/index.tsx
@@ -1,9 +1,10 @@
 import {
   BottomRow,
   CardContainer,
-  EpisodeBadge,
-  EpisodeBadgeText,
+  getRatingColor,
   InfoContainer,
+  MetaRow,
+  MetaText,
   PosterImage,
   PosterPlaceholder,
   RatingContainer,
@@ -12,11 +13,14 @@ import {
   StatusBadge,
   StatusBadgeText,
   TopRow,
+  UserRatingBadge,
+  UserRatingLabel,
+  UserRatingValue,
 } from './styles';
 import type { SeriesCardProps } from './types';
 import { useViewModel } from './viewmodel';
-import { SeriesStatus } from '@/types/database.types';
 import { STATUS_COLORS } from '@/theme/statusColors';
+import { SeriesStatus } from '@/types/database.types';
 import {
   BookmarkIcon,
   CheckCircleIcon,
@@ -61,8 +65,9 @@ export default function SeriesCard({
   poster_path,
   status,
   rating,
-  current_season,
-  current_episode,
+  number_of_seasons,
+  number_of_episodes,
+  vote_average,
   id,
   type,
 }: SeriesCardProps) {
@@ -71,7 +76,7 @@ export default function SeriesCard({
   const { onPress } = useViewModel(type);
 
   const hasPoster = poster_path !== null;
-  const hasProgress = current_season !== null && current_episode !== null;
+  const hasProgress = number_of_episodes !== null && number_of_seasons !== null;
 
   return (
     <CardContainer onPress={() => onPress(id)} activeOpacity={0.9}>
@@ -93,14 +98,25 @@ export default function SeriesCard({
       <InfoContainer>
         <TopRow>
           <SeriesTitle numberOfLines={2}>{series_name}</SeriesTitle>
+          {vote_average !== null && (
+            <RatingContainer>
+              <StarIcon size={16} color="#FBBF24" weight="fill" />
+              <RatingText>{vote_average.toFixed(1)}</RatingText>
+            </RatingContainer>
+          )}
         </TopRow>
 
         {hasProgress && (
-          <EpisodeBadge>
-            <EpisodeBadgeText>
-              {`S${current_season} · E${current_episode}`}
-            </EpisodeBadgeText>
-          </EpisodeBadge>
+          <MetaRow>
+            <MetaText>
+              {number_of_seasons}{' '}
+              {number_of_seasons === 1
+                ? t('seriesCard.seasons')
+                : t('seriesCard.seasonsPlural')}
+              {' · '}
+              {number_of_episodes} {t('seriesCard.episodes')}
+            </MetaText>
+          </MetaRow>
         )}
 
         <BottomRow>
@@ -111,10 +127,17 @@ export default function SeriesCard({
             </StatusBadgeText>
           </StatusBadge>
           {rating !== null && (
-            <RatingContainer>
-              <StarIcon size={16} color="#FBBF24" weight="fill" />
-              <RatingText>{rating.toFixed(1)}</RatingText>
-            </RatingContainer>
+            <UserRatingBadge>
+              <UserRatingLabel>{t('seriesCard.userRating')}</UserRatingLabel>
+              <StarIcon
+                size={14}
+                color={getRatingColor(rating)}
+                weight="fill"
+              />
+              <UserRatingValue $color={getRatingColor(rating)}>
+                {rating.toFixed(1)}
+              </UserRatingValue>
+            </UserRatingBadge>
           )}
         </BottomRow>
       </InfoContainer>

--- a/src/components/SeriesCard/styles.ts
+++ b/src/components/SeriesCard/styles.ts
@@ -5,6 +5,13 @@ import styled from 'styled-components/native';
 
 const getStatusColor = (status: SeriesStatus) => STATUS_COLORS[status];
 
+export const getRatingColor = (rating: number): string => {
+  if (rating >= 7) return '#2DD4BF';
+  if (rating >= 5) return '#FB923C';
+  if (rating >= 3) return '#fb553c';
+  return '#FB7185';
+};
+
 export const CardContainer = styled.TouchableOpacity`
   flex-direction: row;
   background-color: ${({ theme }) => theme.colors.fill.default.medium};
@@ -37,7 +44,7 @@ export const InfoContainer = styled.View`
 export const TopRow = styled.View`
   flex-direction: row;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
 `;
 
 export const SeriesTitle = styled(Text).attrs({ variant: 'headline' })`
@@ -57,17 +64,16 @@ export const RatingText = styled(Text).attrs({ variant: 'caption' })`
   font-weight: 700;
 `;
 
-export const EpisodeBadge = styled.View`
-  background-color: ${({ theme }) => theme.colors.fill.primary.variant};
-  border-radius: 6px;
-  padding: 4px 8px;
-  align-self: flex-start;
-  margin-top: 8px;
+export const MetaRow = styled.View`
+  flex-direction: row;
+  align-items: center;
+  margin-top: 6px;
 `;
 
-export const EpisodeBadgeText = styled(Text).attrs({ variant: 'caption' })`
-  color: ${({ theme }) => theme.colors.textIcon.default.strong};
-  font-weight: 700;
+export const MetaText = styled(Text).attrs({ variant: 'label' })`
+  color: ${({ theme }) => theme.colors.textIcon.default.main};
+  letter-spacing: 0.2px;
+  font-weight: 800;
 `;
 
 export const BottomRow = styled.View`
@@ -95,4 +101,22 @@ export const StatusBadgeText = styled(Text).attrs({ variant: 'caption' })<{
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.5px;
+`;
+
+export const UserRatingBadge = styled.View`
+  flex-direction: row;
+  align-items: center;
+  gap: 3px;
+`;
+
+export const UserRatingLabel = styled(Text).attrs({ variant: 'caption' })`
+  color: ${({ theme }) => theme.colors.textIcon.default.medium};
+  font-weight: 700;
+`;
+
+export const UserRatingValue = styled(Text).attrs({ variant: 'caption' })<{
+  $color: string;
+}>`
+  color: ${({ $color }) => $color};
+  font-weight: 700;
 `;

--- a/src/components/SeriesCard/types.ts
+++ b/src/components/SeriesCard/types.ts
@@ -5,8 +5,9 @@ export type SeriesCardProps = {
   poster_path: string | null;
   status: SeriesStatus;
   rating: number | null;
-  current_season: number | null;
-  current_episode: number | null;
+  number_of_seasons: number | null;
+  number_of_episodes: number | null;
+  vote_average: number | null;
   id: number;
   type: 'series' | 'movie';
 };

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -115,6 +115,12 @@ const en = {
     cancel: 'Cancel',
     confirm: 'Confirm',
   },
+  seriesCard: {
+    seasons: 'season',
+    seasonsPlural: 'seasons',
+    episodes: 'episodes',
+    userRating: 'My rating',
+  },
   homeView: {
     appName: 'MyWatchList',
     welcome: 'Hello, {{name}}',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -113,6 +113,12 @@ const es = {
     cancel: 'Cancelar',
     confirm: 'Confirmar',
   },
+  seriesCard: {
+    seasons: 'temporada',
+    seasonsPlural: 'temporadas',
+    episodes: 'episodios',
+    userRating: 'Mi nota',
+  },
   homeView: {
     appName: 'MyWatchList',
     welcome: 'Hola, {{name}}',

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -48,6 +48,8 @@ export type Database = {
           current_season: number | null;
           id: string;
           notes: string | null;
+          number_of_episodes: number | null;
+          number_of_seasons: number | null;
           poster_path: string | null;
           rating: number | null;
           series_name: string;
@@ -55,6 +57,7 @@ export type Database = {
           tmdb_series_id: number;
           updated_at: string;
           user_id: string;
+          vote_average: number | null;
         };
         Insert: {
           created_at?: string;
@@ -62,6 +65,8 @@ export type Database = {
           current_season?: number | null;
           id?: string;
           notes?: string | null;
+          number_of_episodes?: number | null;
+          number_of_seasons?: number | null;
           poster_path?: string | null;
           rating?: number | null;
           series_name?: string;
@@ -69,6 +74,7 @@ export type Database = {
           tmdb_series_id: number;
           updated_at?: string;
           user_id: string;
+          vote_average?: number | null;
         };
         Update: {
           created_at?: string;
@@ -76,6 +82,8 @@ export type Database = {
           current_season?: number | null;
           id?: string;
           notes?: string | null;
+          number_of_episodes?: number | null;
+          number_of_seasons?: number | null;
           poster_path?: string | null;
           rating?: number | null;
           series_name?: string;
@@ -83,6 +91,7 @@ export type Database = {
           tmdb_series_id?: number;
           updated_at?: string;
           user_id?: string;
+          vote_average?: number | null;
         };
         Relationships: [
           {
@@ -236,9 +245,7 @@ export const Constants = {
   },
 } as const;
 
-// ─── Tipos manuales del proyecto ─────────────────────────────────────────────
-// Estos tipos se añaden a mano y hay que revisarlos tras cada regeneración.
-
+// MANUALLY ADDED TYPES
 export enum SeriesStatus {
   Watching = 'watching',
   Completed = 'completed',
@@ -266,6 +273,9 @@ export type UserSeries = {
   notes: string | null;
   current_season: number | null;
   current_episode: number | null;
+  vote_average: number | null;
+  number_of_seasons: number | null;
+  number_of_episodes: number | null;
   created_at: string;
   updated_at: string;
 };
@@ -279,11 +289,17 @@ export type InsertUserSeries = Omit<
   | 'notes'
   | 'current_season'
   | 'current_episode'
+  | 'vote_average'
+  | 'number_of_seasons'
+  | 'number_of_episodes'
 > & {
   rating?: number | null;
   notes?: string | null;
   current_season?: number | null;
   current_episode?: number | null;
+  vote_average?: number | null;
+  number_of_seasons?: number | null;
+  number_of_episodes?: number | null;
 };
 export type UpdateUserSeries = Partial<
   Omit<UserSeries, 'id' | 'user_id' | 'created_at' | 'updated_at'>

--- a/src/views/detail/viewmodel.ts
+++ b/src/views/detail/viewmodel.ts
@@ -49,6 +49,15 @@ export const useViewModel = (tmdbId: number, type: 'series' | 'movie') => {
         tmdb_series_id: tmdbId,
         series_name: name,
         poster_path: detail.poster_path ?? null,
+        vote_average: detail.vote_average ?? null,
+        number_of_seasons:
+          type === 'series'
+            ? (detail as TmdbSeriesDetail).number_of_seasons
+            : null,
+        number_of_episodes:
+          type === 'series'
+            ? (detail as TmdbSeriesDetail).number_of_episodes
+            : null,
         status,
       };
       await addSeries(data);

--- a/src/views/search/viewmodel.ts
+++ b/src/views/search/viewmodel.ts
@@ -2,7 +2,7 @@ import { useSeries } from '@/context/SeriesContext';
 import { SeriesStatus } from '@/types/database.types';
 import { useAuth } from '@context/AuthContext';
 import type { TmdbSeries } from '@lib/tmdb';
-import { searchSeries } from '@lib/tmdb';
+import { getSerieById, searchSeries } from '@lib/tmdb';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -45,11 +45,16 @@ export const useViewModel = () => {
     if (!selectedSerie || !session?.user.id) return;
     setIsAdding(true);
     try {
+      // Fetch details to get number of seasons/episodes and vote average at the time of adding
+      const details = await getSerieById(selectedSerie.id);
       await addSeriesContext({
         user_id: session.user.id,
         tmdb_series_id: selectedSerie.id,
         series_name: selectedSerie.name,
         poster_path: selectedSerie.poster_path,
+        vote_average: details?.vote_average ?? null,
+        number_of_seasons: details?.number_of_seasons ?? null,
+        number_of_episodes: details?.number_of_episodes ?? null,
         status,
       });
       setIsSuccess(true);

--- a/supabase/migrations/20260412150107_add_tmdb_metadata_to_user_series.sql
+++ b/supabase/migrations/20260412150107_add_tmdb_metadata_to_user_series.sql
@@ -1,0 +1,4 @@
+ALTER TABLE user_series
+  ADD COLUMN vote_average float4 NULL,
+  ADD COLUMN number_of_seasons int4 NULL,
+  ADD COLUMN number_of_episodes int4 NULL;


### PR DESCRIPTION
This pull request enhances the way series metadata is handled and displayed throughout the app. It introduces support for storing and showing the number of seasons, number of episodes, and TMDB vote average for each series. The UI for the series card has been updated to display this new metadata, and related types, translations, and database schema have been updated accordingly.

**Database and Types Support for New Metadata:**
- Added new columns (`vote_average`, `number_of_seasons`, `number_of_episodes`) to the `user_series` table via a migration, and updated all relevant TypeScript types (`UserSeries`, `InsertUserSeries`, etc.) to include these fields. [[1]](diffhunk://#diff-244d5dbe524482f99f71d367b9a7f459191f1753af08ab1a0a055336044bf1ceR1-R4) [[2]](diffhunk://#diff-5b215ddbe1da343b227002e728f9ac8e6d4e3f3579f095d7872deff8061a92b9R51-R94) [[3]](diffhunk://#diff-5b215ddbe1da343b227002e728f9ac8e6d4e3f3579f095d7872deff8061a92b9R276-R278) [[4]](diffhunk://#diff-5b215ddbe1da343b227002e728f9ac8e6d4e3f3579f095d7872deff8061a92b9R292-R302)

**UI/UX Improvements for Series Cards:**
- Updated the `SeriesCard` component and its styles to display the TMDB vote average, number of seasons, and number of episodes, and to show a user rating badge with color coding based on the rating value. [[1]](diffhunk://#diff-3c2e5ac6515e91df10acca442be71294966005d3f7619c8417acab8b30179d89L64-R70) [[2]](diffhunk://#diff-3c2e5ac6515e91df10acca442be71294966005d3f7619c8417acab8b30179d89R101-R119) [[3]](diffhunk://#diff-3c2e5ac6515e91df10acca442be71294966005d3f7619c8417acab8b30179d89L114-R140) [[4]](diffhunk://#diff-f79d89e883147e4713efb8b1a3dee056672eac86ad5e677e336fc4dff2b06fe0R8-R14) [[5]](diffhunk://#diff-f79d89e883147e4713efb8b1a3dee056672eac86ad5e677e336fc4dff2b06fe0L60-R76) [[6]](diffhunk://#diff-f79d89e883147e4713efb8b1a3dee056672eac86ad5e677e336fc4dff2b06fe0R105-R122) [[7]](diffhunk://#diff-d209e5531c9e6a82b4edd629a21ce3057f42c2a06f84a9d43335edbbcffe5d60L8-R10)

**Data Flow and Series Addition:**
- Modified the logic for adding a series (both from search and detail views) to fetch and store the new metadata fields at the time of adding a series. [[1]](diffhunk://#diff-7e7fd9b59b6f5e31ffa30171cea42eaac2c415952808fdeb14f1d4a032fbefe5R52-R60) [[2]](diffhunk://#diff-5fd348f9d60e7e6009be488b05e67cf19324faff93c9a70d58c7197049cacb42L5-R5) [[3]](diffhunk://#diff-5fd348f9d60e7e6009be488b05e67cf19324faff93c9a70d58c7197049cacb42R48-R57)

**Internationalization:**
- Added new translation keys for displaying "season", "seasons", "episodes", and "My rating" in both English and Spanish locales. [[1]](diffhunk://#diff-5d3a6cad982bab6401d067a9ce59dc96f6449d1872222058ab91b48bb00b6929R118-R123) [[2]](diffhunk://#diff-68837a516b9d2dd41c65b8dea62911586ab0c5f044aebbb743d988e1edb21e7dR116-R121)

**Minor UI Logic Fix:**
- Disabled the confirm button in the `AddSerieModal` if the selected status matches the initial status, preventing unnecessary updates.